### PR TITLE
Increase CAN Open timeout for SDO requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canopen",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "CANopen implementation for Javascript",
   "main": "index.js",
   "scripts": {

--- a/src/protocol/SDO.js
+++ b/src/protocol/SDO.js
@@ -709,7 +709,7 @@ class SDO {
             this.server.buffer = Buffer.from([]);
             this.server.timer = setTimeout(
                 () => { this._serverAbort(0x05040000); },
-                100
+                10000
             );
 
             this.device.channel.send({
@@ -776,7 +776,7 @@ class SDO {
             this.server.bufferOffset = 0;
             this.server.timer = setTimeout(
                 () => { this._serverAbort(0x05040000); },
-                100
+                10000
             );
 
             this.device.channel.send({


### PR DESCRIPTION
This PR increases the timeout value to 10 seconds so that we do not get SDO timeouts on SDO operations done over channels with high latency (mobile for example)

part of https://github.com/Proemion/canlink-test-suite/issues/1823